### PR TITLE
Add option to disable decapitations

### DIFF
--- a/mods/GageHud/Menu/en.txt
+++ b/mods/GageHud/Menu/en.txt
@@ -47,6 +47,8 @@
 	"show_headshot_kills_desc" : "Kill Counter shows the headshot kills",
 	"show_ai_kills" : "Show AI kills",
 	"show_ai_kills_desc" : "Kill Counter shows AI kills",
+    "do_decapitations" : "Enable Decapitations",
+    "do_decapitations_desc" : "Should heads go poof on a lethal headshot.",
 	"flashlight_extender" : "Flashlight Extender",
 	"flashlight_extender_desc" : "Extends the range of the Flashlight",
 	"flashlight_range" : "Flashlight Range",

--- a/mods/GageHud/Menu/kill_counter.txt
+++ b/mods/GageHud/Menu/kill_counter.txt
@@ -43,6 +43,15 @@
             "callback": "callback_show_ai_kills",
             "value": "show_ai_kills",
             "default_value": true
+        },
+        {
+            "type": "toggle",
+            "id": "do_decapitations",
+            "title": "do_decapitations",
+            "description": "do_decapitations_desc",
+            "callback": "callback_do_decapitations",
+            "value": "do_decapitations",
+            "default_value": true
         }
     ]
 }

--- a/mods/GageHud/Menu/mod_collection.lua
+++ b/mods/GageHud/Menu/mod_collection.lua
@@ -175,6 +175,11 @@ Hooks:Add( "MenuManagerInitialize", "MenuManagerInitialize_dynamic_hud", functio
 		mod_collection:Save()
 	end	
 	
+    MenuCallbackHandler.callback_do_decapitations = function(self, item)
+		mod_collection._data.do_decapitations = (item:value() =="on")
+		mod_collection:Save()
+	end
+    
 	MenuCallbackHandler.callback_enable_flashlight_extender = function(self, item)
 		mod_collection._data.enable_flashlight_extender = (item:value() =="on")
 		mod_collection:Save()


### PR DESCRIPTION
Giving options to the user is nice, and decapitations can actually ruin some strategies in stealth, where the changed ragdoll will force the user into using an extra bodybag (shadowraid is a perfect example of this with the security room)